### PR TITLE
Allow player to choose which key pauses the game

### DIFF
--- a/src/Patches/GameInput_Patch.cs
+++ b/src/Patches/GameInput_Patch.cs
@@ -73,7 +73,7 @@ public class GameInput_Update_Patch
 	/// </summary>
 	private static void PauseStuff()
 	{
-		if (Main.MySettings.PauseWithPauseButton && Input.GetKeyDown(KeyCode.Pause))
+		if (Main.MySettings.PauseWithKey && Input.GetKeyDown(Main.MySettings.PauseKeyCode))
 		{
 			Func<bool> func;
 			if (GameInput._escapeHandlers.TryGetValue(GameInput.EscapeHandler.Pause, out func) && func())

--- a/src/Settings.cs
+++ b/src/Settings.cs
@@ -1,5 +1,4 @@
-﻿using UI;
-using UnityEngine;
+﻿using UnityEngine;
 using UnityModManagerNet;
 
 namespace better_mouse_mod
@@ -13,7 +12,9 @@ namespace better_mouse_mod
 		
 		//Pause menu
 		public bool DisableEscapeWindowClose = false;
-		public bool PauseWithPauseButton = true;
+		public bool PauseWithKey = true;
+		public KeyCode PauseKeyCode = KeyCode.Pause;
+		private bool SelectingKeyCode = false;
 		
 		//Vehicle controls
 		public bool ChangeThrottleNotchCount_Steam = false;
@@ -62,7 +63,23 @@ namespace better_mouse_mod
 			GUILayout.Label("Pause menu: ");
 			
 			DisableEscapeWindowClose = GUILayout.Toggle(DisableEscapeWindowClose, "Disable closing windows with the escape button, so you can pause without closing all windows (you need to restart the game to apply this)");
-			PauseWithPauseButton = GUILayout.Toggle(PauseWithPauseButton, "Pause the game with the pause/break button on your keyboard, so you don't have to close all windows to do so");
+			PauseWithKey = GUILayout.Toggle(PauseWithKey, "Pause the game with a single keystroke, so you don't have to close all windows to do so. Defaults to the PAUSE key, but can be changed below.");
+			if (PauseWithKey)
+			{
+				GUILayout.BeginHorizontal();
+				GUILayout.Label("Pause key:");
+				if (GUILayout.Button(SelectingKeyCode ? "Press key…" : PauseKeyCode.ToString(), GUILayout.ExpandWidth(false)))
+				{
+					SelectingKeyCode = !SelectingKeyCode;
+				}
+				if (SelectingKeyCode && Event.current.isKey)
+				{
+					PauseKeyCode = Event.current.keyCode;
+					SelectingKeyCode = false;
+				}
+				GUILayout.FlexibleSpace();
+				GUILayout.EndHorizontal();
+			}
 			
 			//Vehicle controls
 			GUILayout.Space(20);


### PR DESCRIPTION
This allows players whose keyboards don't have a PAUSE key—or who would simply prefer to use a different key—to choose a different key to pause the game.

![Screenshot 2024-03-19 155712](https://github.com/t0stiman/rr_better_mouse_mod/assets/66900153/2fd786a6-1226-4351-a9ed-879ef98b0458)
_Choosing a new keybinding._

![Screenshot 2024-03-19 155633](https://github.com/t0stiman/rr_better_mouse_mod/assets/66900153/d7dedef7-30b0-4acf-afe5-76abde94d168)
_Displaying the currently chosen keybinding._

Closes #6.
