### PR TITLE
Tell git to ignore the dist directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 bin
 obj
 build/
+dist/
 packages
 Directory.Build.targets
 Folder.DotSettings.user


### PR DESCRIPTION
This directory and its contents get created when running the `package.ps1` script.